### PR TITLE
Folder arg support

### DIFF
--- a/shared/directory.ts
+++ b/shared/directory.ts
@@ -1,0 +1,44 @@
+import { ensureDirSync } from "https://deno.land/std/fs/mod.ts";
+
+interface DirectoryConstructOptions {
+  path: string;
+  ensureExists?: boolean; // default: false
+}
+
+class Directory {
+  public path: string;
+  public ensureExists: boolean; // default: false
+
+  constructor(options: DirectoryConstructOptions) {
+    this.path = options.path;
+    this.ensureExists = options.ensureExists || false;
+  }
+
+  async validate(): Promise<void> {
+    // verify the directory exists
+    if (this.ensureExists) {
+      const exists = await this.exists();
+      if (!exists) {
+        throw new Error(`directory does not exist: ${this.path}`);
+      }
+    }
+
+    return;
+  }
+
+  // verify the directory exists
+  async exists(): Promise<boolean> {
+    try {
+      const info = await Deno.stat(this.path);
+      return info.isDirectory;
+    } catch (e) {
+      if (e instanceof Deno.errors.NotFound) {
+        return false;
+      } else {
+        throw e;
+      }
+    }
+  }
+}
+
+export { Directory };

--- a/shared/directory_test.ts
+++ b/shared/directory_test.ts
@@ -1,0 +1,65 @@
+import { Directory } from "./directory.ts";
+import { assertEquals, assertThrows, assertThrowsAsync } from "../test_deps.ts";
+
+const { test } = Deno;
+
+/**
+ * Represents a directory on the file system.
+ *
+ * @example
+ * const dirPath = "/path/to/directory";
+ * const dir = new Directory(dirPath);
+ * const dirExists = await dir.exists();
+ * if (!dirExists) {
+ *   await dir.create();
+ * }
+ *
+ * @scenario Validate the presence of an existing directory
+ * @scenario Handle errors that occur when checking for a directory
+ * @scenario Handle file-based and URL-based path names correctly on different platforms
+ * @scenario Use the `async` and `await` keywords to ensure that directory operations are performed asynchronously
+ * @scenario Allow the `ensureExists` option to create the directory if it does not exist
+ * @scenario Throw an error if `ensureExists` is `true` but the directory does not exist
+ */
+
+test({
+  name: "Directory - Validate the presence of an existing directory",
+  fn: async () => {
+    const dir = new Directory({ path: "./testdata/existing_directory" });
+
+    const dirExists = await dir.exists();
+    assertEquals(dirExists, true);
+  },
+});
+
+test({
+  name: "Directory - Validate the absence of a nonexistent directory",
+  fn: async () => {
+    const dir = new Directory({ path: "./testdata/nonexistent_directory" });
+
+    const dirExists = await dir.exists();
+    assertEquals(dirExists, false);
+  },
+});
+
+test({
+  name:
+    "Directory - Expect exists() to return false when checking for a directory that does not exist",
+  fn: async () => {
+    const dir = new Directory({ path: "./testdata/nonexistent_directory" });
+
+    const result = await dir.exists();
+
+    assertEquals(result, false);
+  },
+});
+
+test({
+  name:
+    "Directory - Handle file-based and URL-based path names correctly on different platforms",
+  fn: () => {
+    const dir = new Directory({ path: "./testdata/existing_directory" });
+
+    assertEquals(dir.path, "./testdata/existing_directory");
+  },
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -4,6 +4,7 @@ enum ArgTypes {
   Number = "Number",
   Enum = "Enum",
   File = "File",
+  Directory = "Directory",
 }
 
 type InterfaceKeys<T> = keyof T;

--- a/task.ts
+++ b/task.ts
@@ -3,6 +3,7 @@ import { ArgTypes } from "./shared/types.ts";
 import {
   Argument,
   BooleanArgument,
+  DirectoryArgument,
   EnumArgument,
   FileArgument,
   NumberArgument,
@@ -10,6 +11,7 @@ import {
 } from "./argument.ts";
 import {
   BooleanOption,
+  DirectoryOption,
   EnumOption,
   FileOption,
   NumberOption,
@@ -99,6 +101,11 @@ class Task<TParams> {
   ): void;
   addArgument(
     name: keyof TParams,
+    type: ArgTypes.Directory,
+    proc: CB<DirectoryArgument<TParams>>,
+  ): void;
+  addArgument(
+    name: keyof TParams,
     type: ArgTypes,
     proc: unknown,
   ): void {
@@ -146,7 +153,13 @@ class Task<TParams> {
         );
         break;
       case ArgTypes.Directory:
-        throw new Error("Directory type not implemented");
+        this.arguments.push(
+          new DirectoryArgument<TParams>(
+            name,
+            proc as CB<DirectoryArgument<TParams>>,
+          ),
+        );
+        break;
       default:
         exhaustiveCheck(type);
     }
@@ -176,6 +189,11 @@ class Task<TParams> {
     name: keyof TParams,
     type: ArgTypes.File,
     proc: CB<FileOption<TParams>>,
+  ): void;
+  addOption(
+    name: keyof TParams,
+    type: ArgTypes.Directory,
+    proc: CB<DirectoryOption<TParams>>,
   ): void;
   addOption(
     name: keyof TParams,
@@ -214,7 +232,14 @@ class Task<TParams> {
         );
         break;
       case ArgTypes.Directory:
-        throw new Error("Directory type not implemented");
+        this.options.set(
+          name,
+          new DirectoryOption<TParams>(
+            name,
+            proc as CB<DirectoryOption<TParams>>,
+          ),
+        );
+        break;
       default:
         exhaustiveCheck(type);
     }

--- a/task.ts
+++ b/task.ts
@@ -145,6 +145,8 @@ class Task<TParams> {
           ),
         );
         break;
+      case ArgTypes.Directory:
+        throw new Error("Directory type not implemented");
       default:
         exhaustiveCheck(type);
     }
@@ -211,6 +213,8 @@ class Task<TParams> {
           new FileOption<TParams>(name, proc as CB<FileOption<TParams>>),
         );
         break;
+      case ArgTypes.Directory:
+        throw new Error("Directory type not implemented");
       default:
         exhaustiveCheck(type);
     }

--- a/task_test.ts
+++ b/task_test.ts
@@ -1,5 +1,6 @@
 import { assertEquals, assertThrows } from "./test_deps.ts";
 import { buildTask, Task } from "./task.ts";
+import { Directory } from "./shared/directory.ts";
 import { ArgTypes } from "./mod.ts";
 
 const { test } = Deno;
@@ -224,6 +225,26 @@ test(
       buildTask(list, (t) => {
         t.addOption("foo", ArgTypes.File, (o) => {
           o.desc = "a file path";
+        });
+      });
+    },
+  },
+);
+
+test(
+  {
+    name: "Task() – addOption() with directory path",
+    fn: () => {
+      interface ListOpts {
+        foo: Directory;
+      }
+
+      function list({ foo }: ListOpts): void {
+      }
+
+      buildTask(list, (t) => {
+        t.addOption("foo", ArgTypes.Directory, (o) => {
+          o.desc = "a directory path";
         });
       });
     },

--- a/task_test.ts
+++ b/task_test.ts
@@ -210,7 +210,6 @@ test(
   },
 );
 
-// test for adding an option using a file path
 test(
   {
     name: "Task() – addOption() with file path",


### PR DESCRIPTION
This pull request adds support for a directory option and arguments. It introduces a Directory object to address the lack of a proper directory object in Deno (similar to Deno.FsFile).

Changes:

- Added support for a directory option and arguments
- Introduced a Directory object