### PR TITLE
Better documentation testing

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -16,6 +16,7 @@ interface HelpMessageOpts {
   usageDescription?: string;
   subCommandsList?: Record<string, string>;
   optionsList?: Record<string, string>;
+  argumentsList?: Record<string, string>;
 }
 
 enum SystemMessages {
@@ -77,6 +78,7 @@ function outputHelpMessage(
     usageDescription,
     subCommandsList,
     optionsList,
+    argumentsList,
   }: HelpMessageOpts,
 ): void {
   const paddingX = 2;
@@ -119,6 +121,15 @@ function outputHelpMessage(
     blocks = blocks.concat(titledList(
       "Sub commands",
       subCommandsList,
+      paddingX,
+      paddingY,
+    ));
+  }
+
+  if (argumentsList && Object.values(argumentsList).length > 0) {
+    blocks = blocks.concat(titledList(
+      "Arguments",
+      argumentsList,
       paddingX,
       paddingY,
     ));
@@ -197,6 +208,17 @@ function displayHelpForTask(task: Task<unknown>): void {
     {},
   );
 
+  const argumentsList: Record<string, string> = [...task.arguments].reduce<
+    Record<string, string>
+  >(
+    (sum, argument) => ({
+      ...sum,
+      [`<${argument.name}>`]: argument.desc ||
+        SystemMessages.DescriptionNotProvided,
+    }),
+    {},
+  );
+
   const subCommandsList: Record<string, string> = [...task.subTasks].reduce<
     Record<string, string>
   >(
@@ -212,6 +234,7 @@ function displayHelpForTask(task: Task<unknown>): void {
     description,
     optionsList,
     subCommandsList,
+    argumentsList,
   });
 }
 

--- a/runner.ts
+++ b/runner.ts
@@ -143,13 +143,19 @@ function outputHelpMessage(
     // ignore
   }
 
+  let lines: string[] = [];
   blocks.forEach((block) => {
     const iter = block.render(width);
 
     for (const line of iter) {
-      console.log(line);
+      lines.push(line.trimEnd());
     }
   });
+
+  // add a blank line at the end.  later this is fixed by a Stack component in the format package.
+  lines.push("");
+
+  console.log(lines.join("\n"));
 }
 
 const commands = {

--- a/runner_test.ts
+++ b/runner_test.ts
@@ -587,6 +587,10 @@ test({
 
   a test function named list
 
+  Arguments
+
+      <baz>  A required argument
+
   Options
 
       --foo  foo description

--- a/runner_test.ts
+++ b/runner_test.ts
@@ -523,28 +523,19 @@ test({
 
     // was not called
     assertEquals(childCallArgs, []);
-    //     assertEquals(consoleSpy.callArgs, [`parent
+    assertEquals(consoleSpy.callArgs, [
+      `
+  parent
 
-    // Sub commands:
-    //     child    undefined
-    // `]);
+  Sub commands
 
-    assertEquals(consoleSpy.callArgs.map((x) => String(x).trim()), [
-      "",
-      "parent",
-      "",
-      "Sub commands",
-      "",
-      `child  ${SystemMessages.DescriptionNotProvided}`,
+      child  ${SystemMessages.DescriptionNotProvided}
+`,
     ]);
 
     resetConsoleSpy();
   },
 });
-
-function trim(str: string): string {
-  return str.trim();
-}
 
 test({
   name: "runner – help text formatting",
@@ -589,18 +580,19 @@ test({
 
     await run({ task, args, options });
 
-    assertEquals(consoleSpy.callArgs.map((x) => String(x).trim()), [
-      "",
-      "list",
-      "",
-      "a test function named list",
-      "",
-      "Options",
-      "",
-      "--foo  foo description",
-      "--bar  foo description",
-    ]);
+    assertEquals(
+      consoleSpy.callArgs[0],
+      `
+  list
 
+  a test function named list
+
+  Options
+
+      --foo  foo description
+      --bar  foo description
+`,
+    );
     resetConsoleSpy();
   },
 });


### PR DESCRIPTION

Add support for displaying command-line arguments in the help message of a runner program. This update to runner.ts includes the addition of an `argumentsList` property to the `HelpMessageOpts` interface, as well as modifications to the `outputHelpMessage()` and `displayHelpForTask()` functions to handle the new argument list.

