### PR TITLE
Fix help text width when console size is zero

### DIFF
--- a/runner.ts
+++ b/runner.ts
@@ -145,11 +145,14 @@ function outputHelpMessage(
 
   let width: number = 120;
 
-  // some terminals or runtimes don't provide this, so consoleSize errors.  In those cases, default to the width above.
+  // some environments return a width of 0 which leads to excessive line
+  // wrapping. Fall back to the default when that happens.
   try {
     const { columns } = Deno.consoleSize();
-    width = columns;
-  } catch (e) {
+    if (columns > 0) {
+      width = columns;
+    }
+  } catch (_e) {
     // ignore
   }
 


### PR DESCRIPTION
## Summary
- preserve default help text width when `Deno.consoleSize()` reports a width of `0`

## Testing
- `deno test -A`

------
https://chatgpt.com/codex/tasks/task_e_68478a9ca22c8324ba4d5b81d4bf5ceb